### PR TITLE
Update to 2.2.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ import os
 
 class DoctestConan(ConanFile):
     name = "doctest"
-    version = "2.0.1"
+    version = "2.2.0"
     url = "https://github.com/bincrafters/conan-doctest"
     homepage = "https://github.com/onqtam/doctest"
     author = "Bincrafters <bincrafters@gmail.com>"

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class DoctestConan(ConanFile):
     url = "https://github.com/bincrafters/conan-doctest"
     homepage = "https://github.com/onqtam/doctest"
     author = "Bincrafters <bincrafters@gmail.com>"
-    description = "C++98/C++11 single header testing framework"
+    description = "C++11/14/17/20 single header testing framework"
     license = "MIT"
     exports = ["LICENSE.md"]
     _source_subfolder = "source_subfolder"


### PR DESCRIPTION
Doctest update to 2.2.0 (Dec 5, 2018).
Also updated the description as it doesn't support C++98 anymore. ([onqtam/doctest](https://github.com/onqtam/doctest/))

CI Testing.
* Travis https://travis-ci.com/chamatht/conan-doctest/builds/96600707
* Appveyor https://ci.appveyor.com/project/chamatht/conan-doctest/builds/21461582